### PR TITLE
Update documentation and package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,24 @@
 # DynamicParametersBundle
 
-This bundle provides a way to read parameters from environment variables at runtime.
-The value defined in the container parameter is used as fallback when the environment variable is not available.
+Inspired by [incenteev/dynamic-parameters-bundle](https://github.com/Incenteev/DynamicParametersBundle) and [%env()%](http://symfony.com/blog/new-in-symfony-3-2-runtime-environment-variables) parameters in Symfony 3.2.
 
-[![Build Status](https://travis-ci.org/Incenteev/DynamicParametersBundle.svg?branch=master)](https://travis-ci.org/Incenteev/DynamicParametersBundle)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/Incenteev/DynamicParametersBundle/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/Incenteev/DynamicParametersBundle/?branch=master)
-[![Code Coverage](https://scrutinizer-ci.com/g/Incenteev/DynamicParametersBundle/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/Incenteev/DynamicParametersBundle/?branch=master)
-[![SensioLabsInsight](https://insight.sensiolabs.com/projects/2e97bd6b-7ae8-41d1-b0a7-a3106f21c50d/mini.png)](https://insight.sensiolabs.com/projects/2e97bd6b-7ae8-41d1-b0a7-a3106f21c50d)
-[![Latest Stable Version](https://poser.pugx.org/incenteev/dynamic-parameters-bundle/v/stable.svg)](https://packagist.org/packages/incenteev/dynamic-parameters-bundle)
-[![Latest Unstable Version](https://poser.pugx.org/incenteev/dynamic-parameters-bundle/v/unstable.svg)](https://packagist.org/packages/incenteev/dynamic-parameters-bundle)
-[![License](https://poser.pugx.org/incenteev/dynamic-parameters-bundle/license.svg)](https://packagist.org/packages/incenteev/dynamic-parameters-bundle)
+This bundle provides a way to read parameters from environment variables at runtime in Symfony 2.7 (and up) the same way as in Symfony 3.2 (some limitations apply).
+
+[![Build Status](https://api.travis-ci.org/ecentria/DynamicParametersBundle.svg?branch=master)](https://travis-ci.org/ecentria/DynamicParametersBundle)
 
 ## Installation
 
-Installation is a quick (I promise!) 2 step process:
+Installation is a 2 step process:
 
-1. Download IncenteevDynamicParametersBundle
+1. Download Ecentria fork of IncenteevDynamicParametersBundle
 2. Enable the bundle
 
-### Step 1: Install IncenteevDynamicParametersBundle with composer
+### Step 1: Install bundle with composer
 
 Run the following composer require command:
 
 ```bash
-$ composer require incenteev/dynamic-parameters-bundle
+$ composer require ecentria/dynamic-parameters-bundle
 ```
 
 ### Step 2: Enable the bundle
@@ -44,62 +39,52 @@ public function registerBundles()
 
 ## Usage
 
-Define the map of parameter names with the environment variable used to configure them.
-
+It's highly recommended to use %env()% parameters only as a value for regular parameter:
 ```yaml
-# app/config/config.yml
-incenteev_dynamic_parameters:
-    parameters:
-        database_host: DATABASE_HOST
-        "database.name": DATABASE_NAME
+# app/config/parameters.yml
+parameters:
+    database_host: %env(DATABASE_HOST)%
+```
+and then ``database_host`` can be used in following scenarios:
+```yaml
+parameters:
+    # can be concatenated with strings/parameters
+    dsn: mysql:host=%database_host%;dbname=testdb
+    
+    # can be used in array
+    hosts:
+        - localhost
+        - %database_host%
+    
+# can be used in config
+doctrine:
+    dbal:
+        connections:
+            default:
+                host: %database_host%
+
+# can be used as service argument
+services:
+    foo:
+        class: stdClass
+        arguments:
+            - %database_host%
 ```
 
-Environment variables are always strings. To be able to set parameters of other types, the bundle supports parsing the environment variable as inline Yaml:
+Using ``%env(DATABASE_HOST)%`` directly (instead of ``%database_host%``) has several disadvantages:
 
-```yaml
-# app/config/config.yml
-incenteev_dynamic_parameters:
-    parameters:
-        use_ssl:
-            variable: HAS_SSL
-            yaml: true
-```
-
-### ParameterHandler integration
-
-If you are using the [env-map feature of the Incenteev ParameterHandler](https://github.com/Incenteev/ParameterHandler/#using-environment-variables-to-set-the-parameters),
-you can import the whole env-map very easily:
-
-```yaml
-# app/config/config.yml
-incenteev_dynamic_parameters:
-    import_parameter_handler_map: true
-    parameters:
-        something_else: NOT_IN_THE_COMPOSER_JSON
-```
-
-The ParameterHandler parses the environment variables as inline Yaml, so the Yaml parsing is automatically enabled for these variables when importing the map.
-
-> Note: Any parameter defined explicitly will win over the imported map.
-
-By default, the bundle will look for the composer.json file in ``%kernel.root_dir%/../composer.json``. If you use a non-standard location for your kernel, you can change the path to your composer.json file to read the env-map:
-
-```yaml
-# app/config/config.yml
-incenteev_dynamic_parameters:
-    import_parameter_handler_map: true
-    composer_file: path/to/composer.json
-```
+1. Environment variable name ``DATABASE_HOST`` is duplicated whenever dynamic parameter is used
+1. This use case is not covered with tests as much as recommended one (yet), something might not work as expected
 
 ### Retrieving parameters at runtime
 
-The bundle taks care of service arguments, but changing the behavior of ``$container->getParameter()`` is not possible. However, it exposes a service to get parameters taking the environment variables into account.
+The bundle takes care of service arguments, but changing the behavior of ``$container->getParameter()`` is not possible. However, it exposes a service to get parameters taking the environment variables into account.
 
 ```php
-$this->get('incenteev_dynamic_parameters.retriever')->get('use_ssl');
+$this->get('incenteev_dynamic_parameters.retriever')->get('database_host');
 ```
 
 ## Limitations
 
 - Getting a parameter from the container directly at runtime will not use the environment variable
-- Parameters or arguments built by concatenating other parameters together will not rely on the environment variables (yet)
+- Uppercase names should be used for environment variables

--- a/README.md
+++ b/README.md
@@ -84,6 +84,29 @@ The bundle takes care of service arguments, but changing the behavior of ``$cont
 $this->get('incenteev_dynamic_parameters.retriever')->get('database_host');
 ```
 
+### Default values for dynamic parameters
+There are two options
+
+#### (Recommended) Option 1:  Using ``.env`` file (see [vlucas/phpdotenv](https://github.com/vlucas/phpdotenv))
+```bash
+# .env file in project root
+DATABASE_HOST="localhost"
+```
+This option is forward compatible with Symfony 3.2.
+
+#### Option 2: Using ``%default_env()%`` parameters
+```yaml
+parameters:
+    database_host: %env(DATABASE_HOST)%
+    default_env(DATABASE_HOST): localhost
+```
+This option is **not** forward compatible with Symfony 3.2, where default values are defined as follows:
+```yaml
+parameters:
+    database_host: %env(DATABASE_HOST)%
+    env(DATABASE_HOST): localhost # doesn't work before Symfony 3.2
+```
+
 ## Limitations
 
 - Getting a parameter from the container directly at runtime will not use the environment variable

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,17 @@
 {
-    "name": "incenteev/dynamic-parameters-bundle",
+    "name": "ecentria/dynamic-parameters-bundle",
     "description": "Runtime retrieval of parameters from environment variables for Symfony",
     "keywords": ["symfony parameters", "environment variable"],
-    "homepage": "https://github.com/Incenteev/DynamicParametersBundle",
+    "homepage": "https://github.com/ecentria/DynamicParametersBundle",
     "license": "MIT",
     "authors": [
         {
             "name": "Christophe Coevoet",
             "email": "stof@notk.org"
+        },
+        {
+            "name": "Roman Shumkov",
+            "email": "roman.shumkov@intexsys.lv"
         }
     ],
     "require": {
@@ -27,5 +31,8 @@
         "branch-alias": {
             "dev-master": "1.0.x-dev"
         }
+    },
+    "conflict": {
+        "incenteev/dynamic-parameters-bundle": "*"
     }
 }


### PR DESCRIPTION
Based on https://github.com/Incenteev/DynamicParametersBundle/issues/1, ecentria fork is not going to be merged back into upstream (which totally makes sense), hence new package name ``ecentria/dynamic-parameters-bundle`` in composer.json. 